### PR TITLE
Add http HEAD health check

### DIFF
--- a/http/home/home_routes.go
+++ b/http/home/home_routes.go
@@ -13,6 +13,11 @@ func ConfigRoutes() {
 		ctx.Output.Body([]byte("ok"))
 	})
 
+	// HEAD method may be used for health check such as aliyun SLB
+	beego.Head("/health", func(ctx *context.Context) {
+		ctx.Output.Body([]byte(""))
+	})
+
 	beego.Get("/version", func(ctx *context.Context) {
 		ctx.Output.Body([]byte(g.VERSION))
 	})


### PR DESCRIPTION
健康检查/health只支持GET访求，使用HEAD时返回404。添加了HEAD方法支持，Aliyun SLB的7层健康检查用的就是HEAD方法。
